### PR TITLE
Now querytypes can be specified in uppercase or lowercase.

### DIFF
--- a/cli/Options/RunOptions.cs
+++ b/cli/Options/RunOptions.cs
@@ -90,7 +90,7 @@ namespace dug.Options
                 ParsedQueryTypes = new List<QueryType>();
                 foreach(string queryTypeString in QueryTypes.Split(",")){
                     QueryType parsedQueryType;
-                    if(Enum.TryParse<QueryType>(queryTypeString, out parsedQueryType)){
+                    if(Enum.TryParse<QueryType>(queryTypeString.ToUpperInvariant(), out parsedQueryType)){
                         ParsedQueryTypes.Add(parsedQueryType);
                     }
                     else{


### PR DESCRIPTION
closes #11 