### PR TITLE
Support PRs from forks

### DIFF
--- a/.ci/.drone.yml
+++ b/.ci/.drone.yml
@@ -9,7 +9,7 @@ steps:
   - name: clone
     image: alpine/git
     commands:
-    - git clone --recurse-submodules https://github.com/unfrl/dug.git .
+    - git clone --recurse-submodules $DRONE_REPO_LINK .
     - git checkout $DRONE_COMMIT
     - git submodule update --recursive --remote
 


### PR DESCRIPTION
Now I am using $DRONE_REPO_LINK instead of assuming the repo will always be dugs, this is to support forks.